### PR TITLE
Fixing syntax for K2SE compatibility in Factorio 2.0

### DIFF
--- a/data-util.lua
+++ b/data-util.lua
@@ -504,8 +504,12 @@ function util.se_landfill(params)
         category = "hard-recycling",
         order = "z-b-"..params.ore,
         subgroup = "terrain",
-        result = "landfill",
-        ingredients = {{params.ore, 50}},
+        results = {
+          {type = "item", name = "landfill", amount = 1},
+        },
+        ingredients = {
+          {type = "item", name = params.ore, amount = 50},
+        },
       }
     })
     util.add_unlock("se-recycling-facility", lname)
@@ -587,6 +591,9 @@ function util.se_matter(params)
   if mods["space-exploration"] > "0.6" then
     if not params.quant_in then params.quant_in = params.quant_out end
     if not params.icon_size then params.icon_size = 64 end
+    
+    
+    
     local fname = "matter-fusion-"..params.ore
     local sedata = util.k2() and "se-kr-matter-synthesis-data" or "se-fusion-test-data"
     local sejunk = util.k2() and "se-broken-data" or "se-junk-data"
@@ -611,15 +618,15 @@ function util.se_matter(params)
         energy_required = params.energy_required,
         enabled = false,
         ingredients = {
-          {sedata, 1},
+          {type="item", name=sedata, amount=1},
           {type="fluid", name="se-particle-stream", amount=50},
           {type="fluid", name="se-space-coolant-supercooled", amount=25},
         },
         results = {
-          {params.ore, params.quant_out},
-          {"se-contaminated-scrap", 1},
-          {type=item, name=sedata, amount=1, probability=.99},
-          {type=item, name=sejunk, amount=1, probability=.01},
+          {type="item", name=params.ore, amount=params.quant_out},
+          {type="item", name="se-contaminated-scrap", amount=1},
+          {type="item", name=sedata, amount=1, probability=.99},
+          {type="item", name=sejunk, amount=1, probability=.01},
           {type="fluid", name="se-space-coolant-hot", amount=25, ignored_by_stats=25, ignored_by_productivity=25},
         }
       }
@@ -650,13 +657,13 @@ function util.se_matter(params)
           energy_required = 30,
           enabled = false,
           ingredients = {
-            {"se-kr-matter-liberation-data", 1},
-            {params.ore, params.quant_in},
+            {type="item", name="se-kr-matter-liberation-data", amount=1},
+            {type="item", name=params.ore, amount=params.quant_in},
             {type="fluid", name="se-particle-stream", amount=50},
           },
           results = {
-            {type=item, name="se-kr-matter-liberation-data", amount=1, probability=.99},
-            {type=item, name=sejunk, amount=1, probability=.01},
+            {type="item", name="se-kr-matter-liberation-data", amount=1, probability=.99},
+            {type="item", name=sejunk, amount=1, probability=.01},
             {type="fluid", name="se-particle-stream", amount=params.stream_out, ignored_by_stats=50, ignored_by_productivity=50},
           }
         }

--- a/titanium-recipe-se.lua
+++ b/titanium-recipe-se.lua
@@ -6,7 +6,7 @@ if mods["space-exploration"] then
   se_delivery_cannon_recipes[util.me.titanium_plate] = {name= util.me.titanium_plate}
   util.se_landfill({ore="titanium-ore"})
   
-if string.sub(mods["space-exploration"], 1, 3) == "0.6" then
+if string.sub(mods["space-exploration"], 1, 3) >= "0.6" and string.sub(mods["space-exploration"], 1, 3) < "0.8" then
   util.se_matter({ore="titanium-ore", energy_required=2, quant_out=10, stream_out=60})
   data:extend({
   {
@@ -50,7 +50,7 @@ if string.sub(mods["space-exploration"], 1, 3) == "0.6" then
     },
     energy_required = 60,
     ingredients = {
-      {name = util.k2() and "enriched-titanium" or "titanium-ore", amount = 24},
+      {type = "item", name = util.k2() and "enriched-titanium" or "titanium-ore", amount = 24},
       {type = "fluid", name = "se-pyroflux", amount = 10},
     },
     enabled = false,
@@ -62,7 +62,9 @@ if string.sub(mods["space-exploration"], 1, 3) == "0.6" then
     type = "recipe",
     name = "titanium-ingot",
     category = "casting",
-    results = {{"titanium-ingot", 1}},
+    results = {
+      {type = "item", name = "titanium-ingot", amount = 1},
+    },
     energy_required = 100,
     ingredients = {
       {type = "fluid", name = "molten-titanium", amount = 500},
@@ -81,11 +83,11 @@ if string.sub(mods["space-exploration"], 1, 3) == "0.6" then
       {icon = "__bztitanium__/graphics/icons/titanium-ingot.png", icon_size = 128, scale = 0.125, shift = {-8, -8}},
     },
     results = {
-      {name = "titanium-plate", amount = 10},
+      {type = "item", name = "titanium-plate", amount = 10},
     },
     energy_required = 5,
     ingredients = {
-      {name = "titanium-ingot", amount = 1}
+      {type = "item", name = "titanium-ingot", amount = 1}
     },
     enabled = false,
     always_show_made_in = true,
@@ -121,11 +123,11 @@ else
       always_show_made_in = true,
       allow_as_intermediate = false,
       ingredients = {
-        {name = "enriched-titanium", amount = 8},
-        {name = "se-vulcanite-block", amount = 1},
+        {type = "item", name = "enriched-titanium", amount = 8},
+        {type = "item", name = "se-vulcanite-block", amount = 1},
       },
       results = {
-        {name = util.me.titanium_plate, amount = 6},
+        {type = "item", name = util.me.titanium_plate, amount = 6},
       },
       icons =
       {
@@ -151,11 +153,11 @@ else
       always_show_made_in = true,
       allow_as_intermediate = false,
       ingredients = {
-        {name = "titanium-ore", amount = 20},
-        {name = "se-vulcanite-block", amount = 1},
+        {type = "item", name = "titanium-ore", amount = 20},
+        {type = "item", name = "se-vulcanite-block", amount = 1},
       },
       results = {
-        {name = util.me.titanium_plate, amount = 6},
+        {type = "item", name = util.me.titanium_plate, amount = 6},
       },
       icons =
       {


### PR DESCRIPTION
When the SE code path is enabled with a testing version of SE for Factorio 2.0 (plus a K2SE save file), titanium mod fails to load because of new Lua syntax requirements for things like "results" and "ingredients" in Factorio 2.0. I am not a Lua programmer (just Python and C++), so this is just what ChatGPT suggested I change then cleaned up by me. But, as far as I can tell it fixes the problem and I am able to load my save file.